### PR TITLE
Riding parameter display for random vibration control law.

### DIFF
--- a/src/rattlesnake/user_interface/random_vibration_sys_id_ui.py
+++ b/src/rattlesnake/user_interface/random_vibration_sys_id_ui.py
@@ -684,9 +684,19 @@ class RandomVibrationUI(SysIdEnvironmentUI):
         )
         if metadata.control_python_script:
             self.select_python_module(None, metadata.control_python_script)
-            self.definition_widget.control_function_input.setCurrentIndex(
+            function_index = self.definition_widget.control_function_input.findText(
+                metadata.control_python_function
+            )
+            if function_index >= 0:
+                self.definition_widget.control_function_input.setCurrentIndex(
+                    function_index
+                )
+            self.definition_widget.control_function_generator_selector.setCurrentIndex(
                 metadata.control_python_function_type
             )
+        self.definition_widget.control_parameters_text_input.setPlainText(
+            metadata.control_python_function_parameters or ""
+        )
         self.definition_widget.frequency_lines_out_spinbox.setValue(
             metadata.percent_lines_out
         )


### PR DESCRIPTION
This fix was suggested by AI and makes the control parameters display correctly when loading a random vibration test profile.