### PR TITLE
have validate tag job emit is_prelease bool, two separate paths, one …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
   # 1. VALIDATE: Ensure the tag was created on main or dev
   validate_tag:
     runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.prerelease_check.outputs.is_prerelease }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -91,6 +93,21 @@ jobs:
           print(f"OK: '{new_tag}' ({new_version}) is newer than the latest existing tag '{latest_tag}' ({latest_version}).")
           EOF
 
+      - name: Determine prerelease status
+        # Version.is_prerelease is the single source of truth for whether this
+        # tag is a prerelease (a/b/rc/.dev segments) or a stable/.post release.
+        # github-release and the publish_testpypi/publish_pypi jobs below all
+        # read this one output instead of re-deriving it with their own
+        # substring checks, so the two can never disagree.
+        id: prerelease_check
+        run: |
+          python - <<'EOF' >> "$GITHUB_OUTPUT"
+          from packaging.version import Version
+          tag = "${{ github.ref_name }}"
+          version = Version(tag.lstrip("v"))
+          print(f"is_prerelease={'true' if version.is_prerelease else 'false'}")
+          EOF
+
   # 2. TEST JOB: Runs Pytest
   test:
     needs: validate_tag
@@ -132,7 +149,7 @@ jobs:
 
   # 4. GITHUB RELEASE: Creates the release on GitHub and attaches the build files
   github-release:
-    needs: build
+    needs: [build, validate_tag] # validate_tag is already an ancestor via build -> test -> validate_tag; listed explicitly to access its is_prerelease output
     if: startsWith(github.ref, 'refs/tags/') # Only release on actual tags, redundant to on: push: tags: - 'v*', but safeguards against any other trigger that might be added later.
     runs-on: ubuntu-latest
     permissions:
@@ -151,16 +168,46 @@ jobs:
           files: dist/*
           generate_release_notes: true # Automatically generate release notes based on commits since the last release
           draft: false # Set to true if you want to create a draft release instead of publishing immediately
-          prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') || contains(github.ref, 'a') || contains(github.ref, 'b') }} # Mark as pre-release if tag contains rc, dev, a, or b
+          prerelease: ${{ needs.validate_tag.outputs.is_prerelease == 'true' }} # Single source of truth, computed once in validate_tag
 
-  # 5. PUBLISH: Only runs if 'build' passes
-  publish:
-    name: Publish to PyPI or TestPyPI
-    needs: [build, github-release] # Ensure both build and GitHub release steps succeed before publishing
+  # 5a. PUBLISH (PRERELEASE): Only runs if 'build' passes and the tag is a prerelease
+  publish_testpypi:
+    name: "Publish: TestPyPI (prerelease)"
+    needs: [build, github-release, validate_tag] # validate_tag is already an ancestor; listed explicitly to access its is_prerelease output
+    if: needs.validate_tag.outputs.is_prerelease == 'true'
     runs-on: ubuntu-latest
-    # environment: pypi
-    # Set the environment based on the tag name
-    environment: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'dev')) && 'testpypi' || 'pypi' }} # If the tag contains 'rc' or 'dev', use the 'testpypi' environment, otherwise use 'pypi'
+    environment: testpypi
+    # No approval gate configured on 'testpypi' — prereleases are low-risk by design.
+    permissions:
+      id-token: write # Needed for authentication with TestPyPI using GitHub Actions
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Trusted Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No password needed with Trusted Publishing configured on TestPyPI.
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Write summary
+        run: |
+          {
+            echo "🧪 Published \`${{ github.ref_name }}\` to **TestPyPI** (prerelease)"
+            echo
+            echo "https://test.pypi.org/project/rattlesnake-vibration-controller/"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # 5b. PUBLISH (RELEASE): Only runs if 'build' passes and the tag is a stable/post release
+  publish_pypi:
+    name: "Publish: PyPI (production release)"
+    needs: [build, github-release, validate_tag] # validate_tag is already an ancestor; listed explicitly to access its is_prerelease output
+    if: needs.validate_tag.outputs.is_prerelease == 'false'
+    runs-on: ubuntu-latest
+    environment: pypi
     # Manual approval gate is configured on the 'pypi' GitHub environment (Settings → Environments → pypi → Required reviewers)
     permissions:
       id-token: write # Needed for authentication with PyPI using GitHub Actions
@@ -171,9 +218,15 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Trusted Publish to TestPyPI or PyPI
+      - name: Trusted Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         # No password needed with Trusted Publishing configured on PyPI.
-        with:
-          # If the tag contains 'rc' or 'dev', use the TestPyPI URL; otherwise, use the default PyPI URL
-          repository-url: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'dev')) && 'https://test.pypi.org/legacy/' || '' }}  # Production PyPI uses the default URL, so the empty string will cause it to default to the standard PyPI repository. TestPyPI will use the specified URL. 
+        # No repository-url: the action defaults to production PyPI.
+
+      - name: Write summary
+        run: |
+          {
+            echo "📦 Published \`${{ github.ref_name }}\` to **production PyPI**"
+            echo
+            echo "https://pypi.org/project/rattlesnake-vibration-controller/"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/documentation/book/src/contributing.md
+++ b/documentation/book/src/contributing.md
@@ -358,18 +358,20 @@ Triggered on every push to *any* branch, plus manual dispatch. Six jobs:
 
 `release.yml` — Release Pipeline
 
-Triggered only on `v*` tags. Five sequential jobs:
+Triggered only on `v*` tags. Six sequential jobs:
 
 1. **validate_tag**
    * Verifies the tag was created on the `main` or `dev` branch, that it conforms to PEP 440, and that it is strictly newer than all existing tags.
+   * Also computes an `is_prerelease` job output using `packaging.version.Version(...).is_prerelease` (true for `a`/`b`/`rc`/`.dev` segments, false for stable and `.post` releases). This is the **single source of truth** consumed by every downstream job that needs to distinguish a prerelease from a production release — nothing downstream re-derives it with its own tag matching.
 2. **test**
    * Calls `ci.yml` as a reusable workflow (workflow_call).
 3. **build**
    * Runs `uv build` and generates a Supply chain Levels for Software Artifacts (SLSA, aka "salsa") provenance attestation for the dist artifacts.
 4. **github-release**
-   * Creates a GitHub Release with auto-generated notes and attaches the `dist` files.
-5. **publish**
-   * Publishes to PyPI or TestPyPI via Trusted Publishing. Tags containing `rc` or `dev` go to TestPyPI; all others go to production PyPI.
+   * Creates a GitHub Release with auto-generated notes and attaches the `dist` files. `prerelease:` is set directly from `validate_tag`'s `is_prerelease` output.
+5. **publish_testpypi** / **publish_pypi**
+   * Two separate jobs, mutually exclusive via `if: needs.validate_tag.outputs.is_prerelease == 'true'` / `'false'`. Each has a hardcoded `environment:` (`testpypi` / `pypi`) and hardcoded publish target — no ternary expression to read or evaluate. In the Actions UI this shows as one job succeeding and the other skipped, so which registry a run published to is visible at a glance from the job list alone, and each job's last step also writes an explicit one-line status (e.g. "📦 Published `v1.2.3` to **production PyPI**") to the run's Summary tab.
+   * Splitting into two jobs (rather than two steps in one job) is required because GitHub Actions environments — including the `pypi` environment's required-reviewers approval gate — are configured per-job, not per-step.
 
 ### Details
 
@@ -520,10 +522,16 @@ To configure Trusted Publishing, you tell PyPI, "Trust any code from this specif
 
 Steps:
 
-* In `release.yml`, the environment must be set to either `pypi` or `testpypi` depending on the version string.  Hence the logic in `release.yml`:
+* In `release.yml`, `publish_testpypi` and `publish_pypi` are two separate jobs, each hardcoded to its own environment (`testpypi` / `pypi` respectively). Which one actually runs is decided once, upstream, in `validate_tag`'s `is_prerelease` output:
 
-```bash
-environment: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'dev')) && 'testpypi' || 'pypi' }} # If the tag contains 'rc' or 'dev', use the 'testpypi' environment, otherwise use 'pypi'
+```yaml
+  publish_testpypi:
+    environment: testpypi
+    if: needs.validate_tag.outputs.is_prerelease == 'true'
+
+  publish_pypi:
+    environment: pypi
+    if: needs.validate_tag.outputs.is_prerelease == 'false'
 ```
 
 The GitHub repository itself must have both a `pypi` and a `testpypi` environment:
@@ -647,7 +655,7 @@ git push origin v1.0.0
 
 ### Manual Approval Gate
 
-By default, a tag push triggers the full release pipeline automatically — including the final publish to PyPI — with no human checkpoint. The **manual approval gate** pauses the `publish` job and requires a named reviewer to explicitly approve before the package is uploaded to PyPI.
+By default, a tag push triggers the full release pipeline automatically — including the final publish to PyPI — with no human checkpoint. The **manual approval gate** pauses the `publish_pypi` job and requires a named reviewer to explicitly approve before the package is uploaded to PyPI.
 
 This is an industry-standard safeguard for production releases. It gives a release manager a final opportunity to confirm that the correct tag is being published, the changelog looks right, and no last-minute issues have been flagged.
 
@@ -655,7 +663,7 @@ The approval gate applies only to the production `pypi` environment. The `testpy
 
 #### Setup (GitHub Settings UI)
 
-No changes to `release.yml` are required. The `publish` job dynamically selects `environment: pypi` for stable releases or `environment: testpypi` for prereleases — GitHub uses this environment name as the hook to enforce the approval rule.
+No changes to `release.yml` are required. `publish_pypi` is hardcoded to `environment: pypi` and `publish_testpypi` is hardcoded to `environment: testpypi` — GitHub uses whichever environment name the running job declares as the hook to enforce the approval rule, so it only ever applies to `publish_pypi`.
 
 1. Navigate to the repository on GitHub.
 2. Click the **Settings** tab.
@@ -665,6 +673,6 @@ No changes to `release.yml` are required. The `publish` job dynamically selects 
 6. In the text field that appears, type the GitHub username(s) or team name(s) who are authorized to approve a PyPI release. Add up to 6 reviewers.
 7. Click **Save protection rules**.
 
-When a release tag is pushed, the pipeline will run `validate_tag`, `test`, `build`, and `github-release` automatically. The `publish` job will then pause with status **Waiting**. The designated reviewer(s) will receive a GitHub notification and must click **Review deployments → Approve and deploy** before the package is uploaded to PyPI.
+When a release tag is pushed, the pipeline will run `validate_tag`, `test`, `build`, and `github-release` automatically. For a stable/`.post` tag, the `publish_pypi` job will then pause with status **Waiting** (`publish_testpypi` is skipped, since `is_prerelease` is false). The designated reviewer(s) will receive a GitHub notification and must click **Review deployments → Approve and deploy** before the package is uploaded to PyPI.
 
 If no reviewer approves within 30 days, the deployment times out and must be re-triggered.


### PR DESCRIPTION
…for TestPyPI, the other for PyPI (no remaining colluding and ambiguity on the publishing target).