### PR TITLE
Fix PyPI/TestPyPI logo (root-relative path -> absolute URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Rattlesnake Logo](/logo/Rattlesnake_Logo_Banner.png)
+![Rattlesnake Logo](https://raw.githubusercontent.com/sandialabs/rattlesnake-vibration-controller/main/logo/Rattlesnake_Logo_Banner.png)
 
 # Rattlesnake Vibration Controller
 


### PR DESCRIPTION
The README used a root-relative image path (`/logo/Rattlesnake_Logo_Banner.png`), which GitHub resolves against the repo root but PyPI/TestPyPI cannot — they render the README standalone, so the logo 404s on the project page. Switched to an absolute `raw.githubusercontent.com` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)