### PR TITLE
Fix --strict Jupyter Book build silently passing on missing TOC entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,11 +359,21 @@ jobs:
         with:
           name: ui-generated-docs
           path: documentation/book/src/_generated
+          # Fail loudly rather than uploading an empty artifact. The book's
+          # table of contents lists every generated page, so an empty upload
+          # here breaks the docs_jupyter_book job downstream.
+          if-no-files-found: error
   # This job builds the Jupyter Book documentation and uploads it as an artifact. It runs on Ubuntu with Python 3.12.
   # To test locally:
   # 1. Install uv: https://astral.sh/uv/installation/
   # 2. Run `uv pip install "jupyter-book>=2.0.0"`
-  # 3. Run `cd documentation && uv run jupyter book build --html --strict && cd ..` from the root of the repository to build the book. The output will be in documentation/_build/html
+  # 3. Run `uv run python src/rattlesnake/cicd/toc.py --myst_file documentation/myst.yml` from the root of the repository to check the table of contents
+  # 4. Run `cd documentation && uv run jupyter book build --html --strict && cd ..` from the root of the repository to build the book. The output will be in documentation/_build/html
+  #
+  # Note that step 3 is not redundant. `--strict` does not fail on a missing
+  # table of contents entry. MyST records that error against myst.yml, and the
+  # strict check only inspects errors recorded against pages that made it into
+  # the project. MyST prints the error and then exits zero.
   docs_jupyter_book:
     needs: [changes, docs_ui_generate]
     # Run job if docs changed
@@ -416,10 +426,32 @@ jobs:
             --github_sha ${{ github.sha }} \
             --github_repo ${{ github.repository }}
 
-      - name: Build the book
+      - name: Validate the table of contents
         run: |
-          # Build the book. We use --strict to ensure any errors fail the job.
-          cd documentation && uv run jupyter book build --html --strict && cd ..
+          # Check every table of contents entry before building. The build's
+          # --strict flag does not catch a missing entry, so without this step
+          # a book with missing content deploys as a green build.
+          uv run python src/rattlesnake/cicd/toc.py --myst_file documentation/myst.yml
+
+      - name: Build the book
+        shell: bash
+        run: |
+          set -o pipefail
+
+          # Build the book. We use --strict to ensure any page errors fail the job.
+          BUILD_LOG="${RUNNER_TEMP:-/tmp}/jupyter_book_build.log"
+          cd documentation
+          uv run jupyter book build --html --strict 2>&1 | tee "$BUILD_LOG"
+          cd ..
+
+          # --strict only inspects errors recorded against pages that made it
+          # into the project. Errors recorded against myst.yml itself are
+          # printed and then ignored, and the build exits zero. Scan the log for
+          # the error marker so those fail the job too.
+          if grep -qF '⛔️' "$BUILD_LOG"; then
+            echo "::error::MyST reported errors during the book build; see the ⛔️ lines above."
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/documentation/book/src/contributing.md
+++ b/documentation/book/src/contributing.md
@@ -237,9 +237,32 @@ rattlesnake-vibration-controller/documentation
 
 folder.
 
+(sec:generated-ui-pages)=
+#### Generated User Interface Pages
+
+Seventeen pages under `book/src/_generated` document the Rattlesnake user interface.  The script `documentation/generate_ui_documentation.py` writes them.  It opens each environment's user interface, walks its widget tree, screenshots every widget, and produces one Markdown page per interface along with the figures that page references.
+
+These pages are **not** checked into the repository.  `documentation/.gitignore` excludes `book/src/_generated/**`.  The `docs_ui_generate` job in `.github/workflows/ci.yml` regenerates them on every documentation build.  Its `Generate UI documentation` step runs the script.  Do not update the `book/src/_generated/**` files.
+
+Hand-written chapters cross-reference the generated figures.  `environment_mimo_random.md` links to `fig:random_vibration_definition:cpsd_parameters_groupbox`, for example.  A working tree without the generated pages therefore fails a book build twice over: seventeen table of contents entries do not resolve, and the cross-references from the hand-written chapters do not resolve either.
+
+Generate the pages locally by running this from the repository root:
+
+```sh
+uv run python documentation/generate_ui_documentation.py
+```
+
+The script opens real Qt windows and screenshots them, so it needs a desktop session rather than a headless one.  It also takes a while, roughly half an hour on the CI Windows runner.  Run it once.  The output then persists in your working tree, and you can rebuild the book as often as you like without regenerating the screenshots.
+
+```{note}
+CI runs this job on `windows-latest`.  Windows is where the interface is developed, so its screenshots are the reference.  A macOS or Linux run produces different window decorations and widget metrics, so use the generated pages for a local preview rather than as a match for what CI will publish.
+```
+
 #### Local Build
 
 Within the `documentation` folder, the `myst.yml` file specifies how Jupyter Book should build the documentation.  Importantly, it links to Markdown files that contain the book's content.
+
+Generate the user interface pages first, as described in [Generated User Interface Pages](#sec:generated-ui-pages).  A fresh clone does not contain them, and the build fails without them.
 
 ```sh
 jupyter book build --html --strict
@@ -250,6 +273,20 @@ This will build the Jupyter Book documentation.
 ```{warning}
 The foregoing command may not work behind a corporate firewall, in which case, the simpler `jupyter book build` command should still work.
 ```
+
+````{warning}
+The `--strict` flag does not catch every error MyST prints.  MyST records a missing table of contents entry against `myst.yml`.  The strict check only inspects errors recorded against pages that made it into the project.  MyST prints the error and then exits zero (`success`).  A book missing every page under `book/src/_generated` still builds green.
+
+Check the table of contents separately.  Run the following from the repository root, before the build:
+
+```sh
+python src/rattlesnake/cicd/toc.py --myst_file documentation/myst.yml
+```
+
+The script exits non-zero and lists every entry that does not resolve.  `uv run preflight --docs` runs it for you, along with the build.
+
+Seventeen missing entries under `book/src/_generated` mean you have not generated the user interface pages yet.  See [Generated User Interface Pages](#sec:generated-ui-pages).
+````
 
 The output will be similar to:
 
@@ -343,10 +380,10 @@ Triggered by:
 * `workflow_call`
   * *Example:* `release.yml` invokes `ci.yml` as its `test` job through the `workflow_call` mechanism.
 
-Six jobs, four of which share a gate:
+Seven jobs, five of which share a gate:
 
 * **`pytest_matrix`, `lint`, `coverage`** — run when `code_changed == 'true'` **or** the branch (or PR base branch) is `main`/`dev`.
-* **`docs_jupyter_book`** — runs when `docs_changed == 'true'` **or** the branch (or PR base branch) is `main`/`dev`.
+* **`docs_ui_generate`, `docs_jupyter_book`** — run when `docs_changed == 'true'` **or** the branch (or PR base branch) is `main`/`dev`. `docs_ui_generate` produces the pages under `book/src/_generated`. `docs_jupyter_book` consumes them. `docs_jupyter_book` declares `needs: docs_ui_generate`, so it waits for the producing job to finish before it builds the book.
 * **`deploy`** — runs on `main`/`dev` regardless of whether `code_changed` is `true` or `false`, and regardless of whether `docs_changed` is `true` or `false`.
 
 1. **changes**
@@ -368,9 +405,15 @@ Six jobs, four of which share a gate:
   a redundant environment setup per workflow run.
 4. **coverage**
    * Runs `pytest --cov` via `uv` with the same adaptive test scope, then calls `report_coverage.py` to generate an HTML coverage report artifact.
-5. **docs_jupyter_book**
-   * Updates `myst.yml` metadata via `report_jupyter_book.py`, then builds the Jupyter Book.
-6. **deploy**
+5. **docs_ui_generate**
+   * Runs on `windows-latest`. Executes `documentation/generate_ui_documentation.py`, which opens each environment's user interface, screenshots its widgets, and writes the seventeen pages and their figures into `documentation/book/src/_generated`.
+   * Uploads that folder as the `ui-generated-docs` artifact. The upload uses `if-no-files-found: error`, so an empty generation fails here rather than silently breaking the book downstream.
+   * This job is why `book/src/_generated` is *not* checked into the repository. See [Generated User Interface Pages](#sec:generated-ui-pages).
+   * The job takes roughly half an hour, so the docs gate matters here more than anywhere else.
+6. **docs_jupyter_book**
+   * Downloads the `ui-generated-docs` artifact into `documentation/book/src/_generated`, updates `myst.yml` metadata via `report_jupyter_book.py`, validates the table of contents via `toc.py`, then builds the Jupyter Book.
+   * The table of contents check and the scan of the build log for MyST's `⛔️` error marker both exist because `--strict` alone does not fail the job.  MyST records some errors, a missing table of contents entry among them, against `myst.yml` rather than against a page.  MyST's help text for `--strict` reads "Summarize build warnings and stop on any errors," and MyST does log the missing entry at error level.  The strict check simply never inspects errors recorded against the config file.  So MyST prints them and exits zero (`success`).  This is an upstream gap that our manually-created `toc.py` now guards against.
+7. **deploy**
    * Assembles all artifacts into a `pages/` tree, generates the dashboard (`report_dashboard.py`), creates SVG badges, then clones the `gh-pages` branch, replaces only the current branch's subdirectory (`main/` or `dev/`), and pushes the result back with plain `git` (not `peaceiris/actions-gh-pages` or `actions/deploy-pages` — see the comments in `ci.yml` for why both were rejected).
 
 `release.yml` — Release Pipeline
@@ -490,7 +533,7 @@ option | description
 `--all-tests` | Full suite including `tests/long/`; matches CI on `main`/`dev`
 `--coverage` | Adds `--cov=rattlesnake --cov-report=term-missing` to the pytest run (no effect while pytest is disabled)
 `--tag TAG` | Validates `TAG` before pushing a release: checks current branch is `main` or `dev`, that the tag conforms to PEP 440, and that it is strictly newer than all existing tags. Runs before lint and tests.
-`--docs` | Builds the Jupyter Book with `--strict`; matches the `docs_jupyter_book` CI job. Requires network access to `api.mystmd.org`.
+`--docs` | Validates the table of contents, then builds the Jupyter Book with `--strict` and scans the log for errors `--strict` ignores; matches the `docs_jupyter_book` CI job. Requires network access to `api.mystmd.org`.
 `--no-sync` | Skips `uv sync` (useful when offline or behind a firewall)
 `--skip-network-check` | Skips the initial PyPI connectivity check
 `--force` | Continues even if the network or sync checks fail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest-qt==4.4.0",
+  "pyyaml",  # documentation/myst.yml parsing, see cicd/toc.py
   "requests",
   "ruff",
 ]

--- a/src/rattlesnake/cicd/toc.py
+++ b/src/rattlesnake/cicd/toc.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+MyST Table of Contents Validator
+
+Jupyter Book's ``--strict`` flag does not fail a build when a table of contents
+entry is missing.  MyST records that error against ``myst.yml`` itself.  The
+strict check only inspects errors recorded against pages that made it into the
+project, so it never sees them.  MyST prints the errors and then exits zero.
+
+This module checks the table of contents directly.  Run it before the book
+build so CI fails on missing content:
+
+    python src/rattlesnake/cicd/toc.py --myst_file documentation/myst.yml
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any, Final, NamedTuple, Optional
+
+import yaml
+
+# Extensions MyST appends when a table of contents entry omits one.
+VALID_FILE_EXTENSIONS: Final[tuple[str, ...]] = (
+    ".md",
+    ".ipynb",
+    ".tex",
+    ".myst.json",
+)
+
+
+class Entry(NamedTuple):
+    """A single table of contents entry."""
+
+    value: str
+    is_pattern: bool
+
+
+def load(*, myst_file: str) -> tuple[Path, list]:
+    """
+    Read the table of contents from a MyST configuration file.
+
+    Args:
+        myst_file: Path to the myst.yml configuration file.
+
+    Returns:
+        A tuple of the directory entries resolve against and the raw
+        table of contents items.
+
+    Raises:
+        ValueError: If the file has no usable table of contents.
+    """
+    path: Path = Path(myst_file)
+    with open(path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    if not isinstance(config, dict):
+        raise ValueError(f"{myst_file} does not contain a YAML mapping")
+
+    project = config.get("project") or {}
+    items = project.get("toc", config.get("toc"))
+
+    if items is None:
+        raise ValueError(f"No table of contents found in {myst_file}")
+    if not isinstance(items, list):
+        raise ValueError(f"Table of contents in {myst_file} is not a list")
+
+    return path.parent, items
+
+
+def entries(*, items: Any) -> list[Entry]:
+    """
+    Flatten a table of contents into its file and pattern entries.
+
+    Entries that name neither a file nor a pattern, such as external URLs and
+    title-only groupings, contribute nothing themselves.  Their children are
+    still walked.
+
+    Args:
+        items: A table of contents list, or None.
+
+    Returns:
+        Every file and pattern entry, in document order.
+    """
+    collected: list[Entry] = []
+
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        if "file" in item:
+            collected.append(Entry(value=str(item["file"]), is_pattern=False))
+        elif "pattern" in item:
+            collected.append(Entry(value=str(item["pattern"]), is_pattern=True))
+        collected.extend(entries(items=item.get("children")))
+
+    return collected
+
+
+def _matches_unique(*, base_dir: Path, value: str) -> list[str]:
+    """
+    Find the files MyST would infer for an extensionless entry.
+
+    Matches are deduplicated case-insensitively, because a case-insensitive
+    filesystem reports both ``page.md`` and ``page.MD`` for the same file.
+
+    Args:
+        base_dir: Directory the entry resolves against.
+        value: The entry as written in the table of contents.
+
+    Returns:
+        The unique candidate file names.
+    """
+    unique: dict[str, str] = {}
+
+    for extension in VALID_FILE_EXTENSIONS:
+        for candidate in (f"{value}{extension}", f"{value}{extension.upper()}"):
+            if (base_dir / candidate).exists():
+                unique.setdefault(candidate.lower(), candidate)
+
+    return list(unique.values())
+
+
+def pattern_check(*, base_dir: Path, value: str) -> Optional[str]:
+    """
+    Check that a table of contents pattern matches at least one file.
+
+    Args:
+        base_dir: Directory the pattern resolves against.
+        value: The pattern as written in the table of contents.
+
+    Returns:
+        A problem description, or None if the pattern matches.
+    """
+    if any(base_dir.glob(value)):
+        return None
+    return f"Pattern from table of contents did not match any files: {value}"
+
+
+def file_check(*, base_dir: Path, value: str) -> Optional[str]:
+    """
+    Check that a table of contents file entry resolves to a page.
+
+    The rules mirror MyST's own resolution so this reports the same problems
+    MyST reports, rather than a stricter or looser set.
+
+    Args:
+        base_dir: Directory the entry resolves against.
+        value: The entry as written in the table of contents.
+
+    Returns:
+        A problem description, or None if the entry resolves.
+    """
+    target: Path = base_dir / value
+
+    if target.exists():
+        if target.is_dir():
+            return f"Folder referenced as file in table of contents: {value}"
+        return None
+
+    matches: list[str] = _matches_unique(base_dir=base_dir, value=value)
+
+    if len(matches) > 1:
+        return f"Multiple files match table of contents entry: {value}"
+    if matches:
+        return None
+    if Path(value).suffix:
+        return f"Table of contents entry does not exist: {value}"
+    return f"Unable to resolve table of contents entry: {value}"
+
+
+def entry_check(*, base_dir: Path, entry: Entry) -> Optional[str]:
+    """
+    Check that a single table of contents entry resolves to content.
+
+    Args:
+        base_dir: Directory the entry resolves against.
+        entry: The entry to check.
+
+    Returns:
+        A problem description, or None if the entry resolves.
+    """
+    if entry.is_pattern:
+        return pattern_check(base_dir=base_dir, value=entry.value)
+    return file_check(base_dir=base_dir, value=entry.value)
+
+
+def validate(*, myst_file: str) -> list[str]:
+    """
+    Check every table of contents entry in a MyST configuration file.
+
+    Args:
+        myst_file: Path to the myst.yml configuration file.
+
+    Returns:
+        A problem description for each entry that does not resolve.  An empty
+        list means the table of contents is sound.
+    """
+    base_dir, items = load(myst_file=myst_file)
+
+    problems: list[str] = []
+    for entry in entries(items=items):
+        problem = entry_check(base_dir=base_dir, entry=entry)
+        if problem is not None:
+            problems.append(problem)
+
+    return problems
+
+
+def report(*, myst_file: str) -> int:
+    """
+    Validate a table of contents and print the outcome.
+
+    On GitHub Actions each problem is also emitted as an error annotation so it
+    surfaces in the workflow summary.
+
+    Args:
+        myst_file: Path to the myst.yml configuration file.
+
+    Returns:
+        Exit code, 0 when every entry resolves and 1 otherwise.
+    """
+    try:
+        problems: list[str] = validate(myst_file=myst_file)
+    except (OSError, ValueError, yaml.YAMLError) as error:
+        print(f"[X] Table of contents check failed: {error}")
+        return 1
+
+    if not problems:
+        print(f"[OK] All table of contents entries resolve in {myst_file}")
+        return 0
+
+    annotate: bool = os.environ.get("GITHUB_ACTIONS") == "true"
+    print(f"[X] {len(problems)} table of contents problem(s) in {myst_file}:")
+    for problem in problems:
+        print(f"    - {problem}")
+        if annotate:
+            print(f"::error file={myst_file}::{problem}")
+
+    return 1
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Parse command line arguments.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="Validate the MyST table of contents."
+    )
+    parser.add_argument(
+        "--myst_file", required=True, help="Path to myst.yml configuration file"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Main entry point."""
+    args = parse_arguments()
+    return report(myst_file=args.myst_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rattlesnake/preflight.py
+++ b/src/rattlesnake/preflight.py
@@ -42,6 +42,8 @@ import sys
 import urllib.error
 import urllib.request
 
+from rattlesnake.cicd import toc
+
 
 def check_connectivity(timeout: int = 5) -> tuple:
     """
@@ -95,6 +97,68 @@ def run_step(
     except FileNotFoundError:
         print("Result: [ERROR] (Command not found.)")
         sys.exit(1)
+
+
+# MyST prefixes every error-level log line with this marker.
+MYST_ERROR_MARKER = "⛔️"
+
+
+def docs_checks(*, no_sync: bool) -> bool:
+    """
+    Run the documentation checks that the docs_jupyter_book CI job runs.
+
+    The table of contents is validated before the build because the build's
+    --strict flag does not fail on a missing entry, and the build log is
+    scanned afterward because --strict likewise ignores any other error
+    recorded against myst.yml rather than against a page.
+
+    Args:
+        no_sync: Skip dependency synchronization, matching --no-sync.
+
+    Returns:
+        True if the documentation is sound.
+    """
+    print("\n--- Jupyter Book Table of Contents ---")
+    myst_file: str = os.path.join("documentation", "myst.yml")
+    passed: bool = toc.report(myst_file=myst_file) == 0
+    print("Result: [SUCCESS]" if passed else "Result: [FAILED]")
+    if not passed:
+        print(
+            "\n[TIP] The pages under book/src/_generated are generated, not"
+            " checked in. If those are the missing entries, run"
+            " 'uv run python documentation/generate_ui_documentation.py'."
+        )
+
+    print("\n--- Jupyter Book Build (--html --strict) ---")
+    print("Note: Requires network access to api.mystmd.org.")
+    uv_sync_flag = ["--no-sync"] if no_sync else []
+    with subprocess.Popen(
+        ["uv", "run"]
+        + uv_sync_flag
+        + ["jupyter", "book", "build", "--html", "--strict"],
+        cwd="documentation",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ) as build:
+        # Echo the build as it runs, keeping the error lines for the scan below.
+        errors: list[str] = []
+        for line in build.stdout:
+            print(line, end="")
+            if MYST_ERROR_MARKER in line:
+                errors.append(line.strip())
+
+    if build.returncode != 0:
+        print(f"Result: [FAILED] (Exit code: {build.returncode})")
+        return False
+    if errors:
+        print(f"Result: [FAILED] (MyST reported {len(errors)} error(s))")
+        for error in errors:
+            print(f"    - {error}")
+        return False
+
+    print("Result: [SUCCESS]")
+    return passed
 
 
 def validate_tag_checks(tag: str) -> bool:
@@ -379,22 +443,8 @@ def main() -> None:
 
     # 6. Jupyter Book build (optional — requires network access)
     if args.docs:
-        print("\n--- Jupyter Book Build (--html --strict) ---")
-        print("Note: Requires network access to api.mystmd.org.")
-        uv_sync_flag = ["--no-sync"] if args.no_sync else []
-        docs_result = subprocess.run(
-            ["uv", "run"]
-            + uv_sync_flag
-            + ["jupyter", "book", "build", "--html", "--strict"],
-            cwd="documentation",
-            text=True,
-            check=False,
-        )
-        if docs_result.returncode != 0:
-            print(f"Result: [FAILED] (Exit code: {docs_result.returncode})")
+        if not docs_checks(no_sync=args.no_sync):
             all_passed = False
-        else:
-            print("Result: [SUCCESS]")
 
     print("\n" + "=" * 40)
     if all_passed:

--- a/tests/short/cicd/test_toc.py
+++ b/tests/short/cicd/test_toc.py
@@ -1,0 +1,259 @@
+"""
+Tests for the MyST table of contents validator.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rattlesnake.cicd import toc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_MYST_FILE = REPO_ROOT / "documentation" / "myst.yml"
+
+
+def myst_file_write(tmp_path: Path, toc_items: list) -> str:
+    """
+    Write a minimal myst.yml containing the given table of contents.
+
+    Args:
+        tmp_path: Directory to write into.
+        toc_items: The table of contents list.
+
+    Returns:
+        Path to the written myst.yml.
+    """
+    myst_file = tmp_path / "myst.yml"
+    config = {"version": 1, "project": {"title": "Test", "toc": toc_items}}
+    myst_file.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return str(myst_file)
+
+
+def page_write(tmp_path: Path, relative_path: str) -> Path:
+    """
+    Create a markdown page inside a temporary book.
+
+    Args:
+        tmp_path: Directory to write into.
+        relative_path: Page path relative to tmp_path.
+
+    Returns:
+        The created file path.
+    """
+    page = tmp_path / relative_path
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("# Page\n", encoding="utf-8")
+    return page
+
+
+def test_entries_flattens_nested_children():
+    """Nested children are collected in document order."""
+    items = [
+        {"file": "a.md"},
+        {
+            "file": "b.md",
+            "children": [
+                {"file": "c.md"},
+                {"title": "Group", "children": [{"file": "d.md"}]},
+            ],
+        },
+    ]
+
+    assert [entry.value for entry in toc.entries(items=items)] == [
+        "a.md",
+        "b.md",
+        "c.md",
+        "d.md",
+    ]
+
+
+def test_entries_skips_urls_and_titles():
+    """URL and title-only entries contribute nothing, but children are walked."""
+    items = [
+        {"url": "https://example.com", "title": "External"},
+        {"title": "Developer's Guide", "children": [{"file": "deep.md"}]},
+    ]
+
+    entries = toc.entries(items=items)
+
+    assert len(entries) == 1
+    assert entries[0] == toc.Entry(value="deep.md", is_pattern=False)
+
+
+def test_entries_records_patterns():
+    """Pattern entries are collected and flagged as patterns."""
+    entries = toc.entries(items=[{"pattern": "chapters/*.md"}])
+
+    assert entries == [toc.Entry(value="chapters/*.md", is_pattern=True)]
+
+
+def test_entries_handles_missing_items():
+    """A None or empty table of contents yields no entries."""
+    assert toc.entries(items=None) == []
+    assert toc.entries(items=[]) == []
+
+
+def test_validate_passes_when_every_entry_exists(tmp_path):
+    """A table of contents pointing at real files reports no problems."""
+    page_write(tmp_path, "book/src/index.md")
+    page_write(tmp_path, "book/src/chapter.md")
+    myst_file = myst_file_write(
+        tmp_path,
+        [
+            {"file": "book/src/index.md"},
+            {"file": "book/src/chapter.md"},
+        ],
+    )
+
+    assert toc.validate(myst_file=myst_file) == []
+
+
+def test_validate_reports_missing_entry(tmp_path):
+    """The missing-content case that --strict fails to catch is reported."""
+    page_write(tmp_path, "book/src/index.md")
+    page_write(tmp_path, "book/src/ui_documentation.md")
+    myst_file = myst_file_write(
+        tmp_path,
+        [
+            {"file": "book/src/index.md"},
+            {
+                "file": "book/src/ui_documentation.md",
+                "children": [{"file": "book/src/_generated/sine_run_doc.md"}],
+            },
+        ],
+    )
+
+    problems = toc.validate(myst_file=myst_file)
+
+    assert problems == [
+        "Table of contents entry does not exist: book/src/_generated/sine_run_doc.md"
+    ]
+
+
+def test_validate_infers_extension(tmp_path):
+    """An extensionless entry resolves when exactly one candidate exists."""
+    page_write(tmp_path, "book/src/index.md")
+    myst_file = myst_file_write(tmp_path, [{"file": "book/src/index"}])
+
+    assert toc.validate(myst_file=myst_file) == []
+
+
+def test_validate_reports_unresolvable_extensionless_entry(tmp_path):
+    """An extensionless entry with no candidate file is reported."""
+    myst_file = myst_file_write(tmp_path, [{"file": "book/src/index"}])
+
+    assert toc.validate(myst_file=myst_file) == [
+        "Unable to resolve table of contents entry: book/src/index"
+    ]
+
+
+def test_validate_reports_folder_used_as_file(tmp_path):
+    """A directory named where a file belongs is reported."""
+    (tmp_path / "book" / "src").mkdir(parents=True)
+    myst_file = myst_file_write(tmp_path, [{"file": "book/src"}])
+
+    assert toc.validate(myst_file=myst_file) == [
+        "Folder referenced as file in table of contents: book/src"
+    ]
+
+
+def test_validate_reports_empty_pattern(tmp_path):
+    """A pattern matching nothing is reported."""
+    page_write(tmp_path, "book/src/index.md")
+    myst_file = myst_file_write(
+        tmp_path,
+        [{"file": "book/src/index.md"}, {"pattern": "book/src/_generated/*.md"}],
+    )
+
+    assert toc.validate(myst_file=myst_file) == [
+        "Pattern from table of contents did not match any files: "
+        "book/src/_generated/*.md"
+    ]
+
+
+def test_validate_accepts_matching_pattern(tmp_path):
+    """A pattern matching at least one file reports no problem."""
+    page_write(tmp_path, "book/src/index.md")
+    page_write(tmp_path, "book/src/_generated/sine_run_doc.md")
+    myst_file = myst_file_write(
+        tmp_path,
+        [{"file": "book/src/index.md"}, {"pattern": "book/src/_generated/*.md"}],
+    )
+
+    assert toc.validate(myst_file=myst_file) == []
+
+
+def test_load_rejects_file_without_toc(tmp_path):
+    """A configuration file with no table of contents raises."""
+    myst_file = tmp_path / "myst.yml"
+    myst_file.write_text(
+        yaml.safe_dump({"version": 1, "project": {}}), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="No table of contents"):
+        toc.load(myst_file=str(myst_file))
+
+
+def test_load_rejects_non_mapping(tmp_path):
+    """A configuration file that is not a mapping raises."""
+    myst_file = tmp_path / "myst.yml"
+    myst_file.write_text("- just\n- a list\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not contain a YAML mapping"):
+        toc.load(myst_file=str(myst_file))
+
+
+def test_report_returns_zero_when_sound(tmp_path, capsys):
+    """A sound table of contents exits 0 and says so."""
+    page_write(tmp_path, "book/src/index.md")
+    myst_file = myst_file_write(tmp_path, [{"file": "book/src/index.md"}])
+
+    assert toc.report(myst_file=myst_file) == 0
+    assert "[OK]" in capsys.readouterr().out
+
+
+def test_report_returns_one_and_lists_problems(tmp_path, capsys, monkeypatch):
+    """A broken table of contents exits 1 and annotates the problems."""
+    page_write(tmp_path, "book/src/index.md")
+    myst_file = myst_file_write(
+        tmp_path,
+        [{"file": "book/src/index.md"}, {"file": "book/src/missing.md"}],
+    )
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    assert toc.report(myst_file=myst_file) == 1
+
+    output = capsys.readouterr().out
+    assert "1 table of contents problem(s)" in output
+    assert "- Table of contents entry does not exist: book/src/missing.md" in output
+    assert f"::error file={myst_file}::" in output
+
+
+def test_report_returns_one_for_unreadable_file(tmp_path, capsys):
+    """A missing configuration file exits 1 rather than raising."""
+    assert toc.report(myst_file=str(tmp_path / "absent.yml")) == 1
+    assert "[X] Table of contents check failed" in capsys.readouterr().out
+
+
+def test_main_uses_command_line_argument(tmp_path, monkeypatch):
+    """The CLI entry point validates the file named on the command line."""
+    page_write(tmp_path, "book/src/index.md")
+    myst_file = myst_file_write(tmp_path, [{"file": "book/src/index.md"}])
+    monkeypatch.setattr("sys.argv", ["toc.py", "--myst_file", myst_file])
+
+    assert toc.main() == 0
+
+
+@pytest.mark.skipif(
+    not REPO_MYST_FILE.is_file(), reason="documentation/ is not part of the sdist"
+)
+def test_repo_myst_file_parses():
+    """The repository's own myst.yml exposes a table of contents we can read."""
+    base_dir, items = toc.load(myst_file=str(REPO_MYST_FILE))
+    values = [entry.value for entry in toc.entries(items=items)]
+
+    assert base_dir == REPO_MYST_FILE.parent
+    assert "book/src/introduction.md" in values
+    assert "book/src/_generated/sine_run_doc.md" in values

--- a/tests/short/test_preflight.py
+++ b/tests/short/test_preflight.py
@@ -1,0 +1,93 @@
+"""
+Tests for the preflight documentation checks.
+"""
+
+import subprocess
+
+from rattlesnake import preflight
+
+
+class FakeBuild:
+    """Stand-in for the Popen handle of a Jupyter Book build."""
+
+    def __init__(self, lines: list[str], returncode: int = 0):
+        self.stdout = iter(lines)
+        self.returncode = returncode
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def build_patch(monkeypatch, lines: list[str], returncode: int = 0) -> None:
+    """
+    Replace the Jupyter Book build with a canned run.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        lines: Lines the build writes to stdout.
+        returncode: Exit code the build reports.
+    """
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda *args, **kwargs: FakeBuild(lines, returncode),
+    )
+
+
+def toc_patch(monkeypatch, exit_code: int) -> None:
+    """
+    Replace the table of contents check with a canned result.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        exit_code: Exit code the check reports.
+    """
+    monkeypatch.setattr(preflight.toc, "report", lambda **kwargs: exit_code)
+
+
+def test_docs_checks_passes_on_a_clean_build(monkeypatch):
+    """A sound table of contents and an error-free build pass."""
+    toc_patch(monkeypatch, 0)
+    build_patch(monkeypatch, ["📚 Built 28 pages for project in 4.57 s.\n"])
+
+    assert preflight.docs_checks(no_sync=True) is True
+
+
+def test_docs_checks_fails_on_errors_the_strict_flag_ignores(monkeypatch, capsys):
+    """
+    MyST errors recorded against myst.yml fail the check.
+
+    These are the errors --strict prints and then ignores, so the build itself
+    reports success. Without the log scan they reach the deployed book.
+    """
+    toc_patch(monkeypatch, 0)
+    build_patch(
+        monkeypatch,
+        [
+            "⛔️ myst.yml Table of contents entry does not exist: "
+            "book/src/_generated/sine_run_doc.md\n",
+            "📚 Built 28 pages for project in 4.57 s.\n",
+        ],
+    )
+
+    assert preflight.docs_checks(no_sync=True) is False
+    assert "MyST reported 1 error(s)" in capsys.readouterr().out
+
+
+def test_docs_checks_fails_on_a_broken_table_of_contents(monkeypatch):
+    """A table of contents problem fails the check even when the build is clean."""
+    toc_patch(monkeypatch, 1)
+    build_patch(monkeypatch, ["📚 Built 28 pages for project in 4.57 s.\n"])
+
+    assert preflight.docs_checks(no_sync=True) is False
+
+
+def test_docs_checks_fails_on_a_failed_build(monkeypatch):
+    """A nonzero build exit code fails the check."""
+    toc_patch(monkeypatch, 0)
+    build_patch(monkeypatch, ["Site has 5 errors, stopping build.\n"], returncode=1)
+
+    assert preflight.docs_checks(no_sync=True) is False

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -754,17 +754,17 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'ARM64') or (python_full_version < '3.11' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
 wheels = [
@@ -780,17 +780,17 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'ARM64') or (python_full_version == '3.11.*' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.11.*'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version == '3.11.*'" },
-    { name = "jedi", marker = "python_full_version == '3.11.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.11.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.11.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -812,16 +812,16 @@ resolution-markers = [
     "(python_full_version >= '4' and platform_machine != 'ARM64') or (python_full_version >= '4' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -833,7 +833,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1258,9 +1258,9 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'ARM64' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.11' and platform_machine == 'ARM64' and sys_platform == 'win32'" },
-    { name = "cftime", marker = "python_full_version < '3.11' and platform_machine == 'ARM64' and sys_platform == 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'ARM64' and sys_platform == 'win32'" },
+    { name = "certifi" },
+    { name = "cftime" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/76/7bc801796dee752c1ce9cd6935564a6ee79d5c9d9ef9192f57b156495a35/netcdf4-1.7.3.tar.gz", hash = "sha256:83f122fc3415e92b1d4904fd6a0898468b5404c09432c34beb6b16c533884673", size = 836095, upload-time = "2025-10-13T18:38:00.76Z" }
 
@@ -1282,8 +1282,8 @@ resolution-markers = [
     "(python_full_version >= '4' and platform_machine != 'ARM64') or (python_full_version >= '4' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.11' or platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "cftime", marker = "python_full_version >= '3.11' or platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "certifi" },
+    { name = "cftime" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'ARM64') or (python_full_version < '3.11' and sys_platform != 'win32')" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
@@ -1568,7 +1568,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1771,8 +1771,8 @@ name = "pyqt6"
 version = "6.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyqt6-qt6", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "pyqt6-sip", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "pyqt6-qt6" },
+    { name = "pyqt6-sip" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/03/e756f52e8b0d7bb5527baf8c46d59af0746391943bdb8655acba22ee4168/pyqt6-6.10.2.tar.gz", hash = "sha256:6c0db5d8cbb9a3e7e2b5b51d0ff3f283121fa27b864db6d2f35b663c9be5cc83", size = 1085573, upload-time = "2026-01-08T16:40:00.244Z" }
 wheels = [
@@ -2084,6 +2084,7 @@ dependencies = [
     { name = "pyqt5", marker = "sys_platform != 'darwin'" },
     { name = "pyqt6", marker = "sys_platform == 'darwin'" },
     { name = "pyqtgraph" },
+    { name = "pytz" },
     { name = "qtpy" },
     { name = "requests" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2100,7 +2101,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
-    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "requests" },
     { name = "ruff" },
 ]
 
@@ -2123,9 +2125,11 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-qt", marker = "extra == 'dev'", specifier = "==4.4.0" },
-    { name = "pytz", marker = "extra == 'dev'" },
+    { name = "pytz" },
+    { name = "pyyaml", marker = "extra == 'dev'" },
     { name = "qtpy" },
     { name = "requests" },
+    { name = "requests", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scipy" },
 ]
@@ -2349,7 +2353,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'ARM64') or (python_full_version < '3.11' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2417,7 +2421,7 @@ resolution-markers = [
     "(python_full_version >= '4' and platform_machine != 'ARM64') or (python_full_version >= '4' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [


### PR DESCRIPTION
MyST records a missing table of contents entry as an error against myst.yml rather than against a page. The --strict check only inspects errors recorded against pages that made it into the project, so it never sees these. MyST prints the error and exits zero.

Add src/rattlesnake/cicd/toc.py, which validates every table of contents entry directly (files, patterns, and nested children) using the same resolution rules MyST uses, and exits non-zero when any entry does not resolve.

Wire it into ci.yml's docs_jupyter_book job before the build, and add a log scan after the build that fails on any MyST error-level line, in case other errors are recorded against myst.yml. Add if-no-files-found: error to the docs_ui_generate artifact upload so an empty UI doc generation fails at the source.

Update preflight --docs to run the same checks locally, and document the generated book/src/_generated pages, the docs_ui_generate CI job, and the --strict gap in contributing.md.