### PR TITLE
Fix UnicodeEncodeError in preflight docs_checks on narrow stdout encodings

### DIFF
--- a/src/rattlesnake/preflight.py
+++ b/src/rattlesnake/preflight.py
@@ -103,6 +103,30 @@ def run_step(
 MYST_ERROR_MARKER = "⛔️"
 
 
+def _console_print(text: str, *, end: str = "\n") -> None:
+    """
+    Print text that may contain characters the terminal cannot encode.
+
+    MyST's build output is full of emoji (⛔️, 📚, 🔗, ...). Some terminals,
+    most notably the default Windows console codec ("charmap"/cp1252), cannot
+    encode them, and pytest's default file-descriptor capture goes through
+    that same codec even though nothing is actually rendered to a screen. So
+    the failure is not cosmetic: a plain print() can crash a real preflight
+    run on Windows. Fall back to a printable approximation rather than
+    raising.
+
+    Args:
+        text: The text to print.
+        end: String appended after the text, matching print()'s parameter.
+    """
+    try:
+        print(text, end=end)
+    except UnicodeEncodeError:
+        encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+        safe = text.encode(encoding, errors="backslashreplace").decode(encoding)
+        print(safe, end=end)
+
+
 def docs_checks(*, no_sync: bool) -> bool:
     """
     Run the documentation checks that the docs_jupyter_book CI job runs.
@@ -140,11 +164,17 @@ def docs_checks(*, no_sync: bool) -> bool:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        # MyST (a Node.js CLI) writes UTF-8 regardless of platform. Decode
+        # explicitly rather than falling back to the locale's preferred
+        # encoding, which on Windows is typically cp1252 and would garble or
+        # reject the build's emoji.
+        encoding="utf-8",
+        errors="replace",
     ) as build:
         # Echo the build as it runs, keeping the error lines for the scan below.
         errors: list[str] = []
         for line in build.stdout:
-            print(line, end="")
+            _console_print(line, end="")
             if MYST_ERROR_MARKER in line:
                 errors.append(line.strip())
 
@@ -154,7 +184,7 @@ def docs_checks(*, no_sync: bool) -> bool:
     if errors:
         print(f"Result: [FAILED] (MyST reported {len(errors)} error(s))")
         for error in errors:
-            print(f"    - {error}")
+            _console_print(f"    - {error}")
         return False
 
     print("Result: [SUCCESS]")

--- a/tests/short/test_preflight.py
+++ b/tests/short/test_preflight.py
@@ -2,7 +2,9 @@
 Tests for the preflight documentation checks.
 """
 
+import io
 import subprocess
+import sys
 
 from rattlesnake import preflight
 
@@ -91,3 +93,51 @@ def test_docs_checks_fails_on_a_failed_build(monkeypatch):
     build_patch(monkeypatch, ["Site has 5 errors, stopping build.\n"], returncode=1)
 
     assert preflight.docs_checks(no_sync=True) is False
+
+
+def narrow_stdout_patch(monkeypatch, *, encoding: str) -> io.BytesIO:
+    """
+    Replace sys.stdout with a stream restricted to the given encoding.
+
+    Reproduces the default Windows console codec ("charmap"/cp1252), which
+    cannot encode MyST's emoji. pytest's own file-descriptor capture goes
+    through that same codec, so this is not a synthetic scenario: it is what
+    actually failed on the Windows CI runner.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        encoding: The encoding to restrict sys.stdout to.
+
+    Returns:
+        The underlying buffer, for inspecting what was actually written.
+    """
+    buffer = io.BytesIO()
+    stream = io.TextIOWrapper(buffer, encoding=encoding, newline="")
+    monkeypatch.setattr(sys, "stdout", stream)
+    return buffer
+
+
+def test_console_print_falls_back_when_the_stream_cannot_encode_the_text(monkeypatch):
+    """A narrow stdout encoding does not raise; unencodable text degrades instead."""
+    buffer = narrow_stdout_patch(monkeypatch, encoding="cp1252")
+
+    preflight._console_print("📚 Built 28 pages for project in 4.57 s.\n", end="")
+    sys.stdout.flush()
+
+    written = buffer.getvalue().decode("cp1252")
+    assert "Built 28 pages" in written
+    assert "📚" not in written
+
+
+def test_docs_checks_survives_a_narrow_stdout_encoding(monkeypatch):
+    """
+    The exact failure seen on Windows CI: stdout cannot encode MyST's emoji.
+
+    Before the fix, printing the build's emoji-laden output crashed with
+    UnicodeEncodeError under cp1252 instead of reporting a check result.
+    """
+    toc_patch(monkeypatch, 0)
+    build_patch(monkeypatch, ["📚 Built 28 pages for project in 4.57 s.\n"])
+    narrow_stdout_patch(monkeypatch, encoding="cp1252")
+
+    assert preflight.docs_checks(no_sync=True) is True


### PR DESCRIPTION
CI failed on windows-latest (run [33214354967](https://github.com/sandialabs/rattlesnake-vibration-controller/actions/runs/33214354967)):

```
FAILED tests/short/test_preflight.py::test_docs_checks_passes_on_a_clean_build - UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4da' in position 0: character maps to <undefined>
FAILED tests/short/test_preflight.py::test_docs_checks_fails_on_a_broken_table_of_contents - UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4da' in position 0: character maps to <undefined>
```

## Root cause

`docs_checks()` echoes MyST's build output as it streams, and that output is full of emoji (⛔️, 📚, 🔗, ...). The default Windows console codec (cp1252, "charmap") cannot encode them. pytest's file-descriptor capture goes through that same codec even though nothing is actually rendered to a screen, so the test suite reproduced the failure directly. This is not just a test artifact — a real `preflight --docs` run on a native Windows machine would hit the same crash.

## Fix

- Add `_console_print()`, which falls back to a backslash-escaped approximation instead of raising when the destination stream cannot encode the text. Used wherever `docs_checks()` echoes MyST's output or error lines.
- Decode the `jupyter book build` subprocess as UTF-8 explicitly rather than the locale's preferred encoding. MyST (a Node.js CLI) always writes UTF-8; the previous `text=True` default would garble or reject it under cp1252 on a real Windows preflight run.
- Add two regression tests that reproduce the exact failure by wrapping `sys.stdout` in a real `cp1252` `TextIOWrapper`, matching what pytest's capture does on the Windows runner. Confirmed both fail against the pre-fix code and pass against the fix.

`tests/short` (653 tests) passes locally.