### PR TITLE
Stop linking the branch name in the Jupyter Book footer

### DIFF
--- a/src/rattlesnake/cicd/report_jupyter_book.py
+++ b/src/rattlesnake/cicd/report_jupyter_book.py
@@ -28,7 +28,6 @@ def generate_footer(metadata: ReportMetadata) -> str:
     """
     github_url = f"https://github.com/{metadata.github_repo}"
     run_url = f"{github_url}/actions/runs/{metadata.run_id}"
-    branch_url = f"{github_url}/tree/{metadata.ref_name}"
     commit_url = f"{github_url}/commit/{metadata.github_sha}"
 
     ts_lines = get_multiline_timestamp(metadata.timestamp)
@@ -42,7 +41,15 @@ def generate_footer(metadata: ReportMetadata) -> str:
         f"{indent}&nbsp;&nbsp;{ts_lines[3]}<br>\n"
         f"{indent}&nbsp;&nbsp;{ts_lines[4]}<br>\n"
         f'{indent}Run ID: <a href="{run_url}">{metadata.run_id}</a><br>\n'
-        f'{indent}Branch: <a href="{branch_url}">{metadata.ref_name}</a><br>\n'
+        # Branch is deliberately plain text, not a link to .../tree/{ref_name}.
+        # A feature branch is often deleted right after its PR merges, and
+        # docs_ui_generate alone takes ~25 minutes, so the strict build's own
+        # link checker can lose that race and fail on a now-dead branch URL.
+        # main/dev persist, but the footer has no way to tell which case it's
+        # in, so treat every branch as ephemeral. The commit link below is
+        # stable: GitHub keeps a commit's page reachable by SHA independent
+        # of whether the branch that pointed to it still exists.
+        f"{indent}Branch: {metadata.ref_name}<br>\n"
         f'{indent}Commit: <a href="{commit_url}">{metadata.github_sha[:7]}</a><br>\n'
         f"{indent}</div>\n"
         f"\n"

--- a/tests/short/cicd/test_report_jupyter_book.py
+++ b/tests/short/cicd/test_report_jupyter_book.py
@@ -32,10 +32,33 @@ def test_generate_footer():
     assert "&nbsp;&nbsp;2024-03-24 08:00:00 EST<br>" in footer
     assert "&nbsp;&nbsp;2024-03-24 06:00:00 MST<br>" in footer
     assert 'Run ID: <a href="https://github.com/owner/repo/actions/runs/12345678">12345678</a><br>' in footer
-    assert 'Branch: <a href="https://github.com/owner/repo/tree/main">main</a><br>' in footer
+    assert "Branch: main<br>" in footer
     assert 'Commit: <a href="https://github.com/owner/repo/commit/abc123456789">abc1234</a><br>' in footer
     assert "owner/repo" in footer
     assert "Repository:" not in footer
+
+
+def test_generate_footer_does_not_link_the_branch():
+    """
+    The branch line is plain text, not a link to .../tree/{ref_name}.
+
+    A feature branch is commonly deleted right after its PR merges, and
+    docs_ui_generate alone takes ~25 minutes. If the branch is linked, the
+    strict build's own link checker can lose that race against the deletion
+    and fail the job on a now-dead URL, even though the merge succeeded.
+    """
+    metadata = ReportMetadata(
+        timestamp="20240324_120000_UTC",
+        run_id="12345678",
+        ref_name="dev-preflight",
+        github_sha="abc123456789",
+        github_repo="owner/repo",
+    )
+
+    footer = generate_footer(metadata)
+
+    assert "https://github.com/owner/repo/tree/dev-preflight" not in footer
+    assert "Branch: dev-preflight<br>" in footer
 
 
 def test_update_myst_file_success(tmp_path):


### PR DESCRIPTION
`docs_jupyter_book` failed on `dev-preflight`'s own CI runs ([push](https://github.com/sandialabs/rattlesnake-vibration-controller/actions/runs/33216132296), [pull_request](https://github.com/sandialabs/rattlesnake-vibration-controller/actions/runs/33216306543)) after PR #134 merged, even though the merge itself succeeded and `dev`'s own run went green:

```
⛔️ myst.yml#site.parts.primary_sidebar_footer Link for "https://github.com/sandialabs/rattlesnake-vibration-controller/tree/dev-preflight" did not resolve. (404, Not Found)
```

## Root cause

`report_jupyter_book.py`'s `generate_footer()` links the branch name into the sidebar footer: `.../tree/{ref_name}`. `docs_ui_generate` + `docs_jupyter_book` together take roughly 25 minutes. A feature branch commonly gets deleted right when its PR merges (auto-delete-head-branches), so by the time MyST's `--strict` link checker reaches that footer link, the branch is already gone and the check 404s — failing a job whose actual content was already merged fine.

`main` and `dev` happen to persist, so this never showed up before, but it will recur on every fast-merged feature branch now that CI takes this long.

## Fix

Render the branch as plain text instead of a link. The commit line is untouched: GitHub keeps a commit's page reachable by SHA regardless of whether the branch that pointed to it still exists, so it remains the reliable way to trace a build.

Added a regression test reproducing the exact `dev-preflight` scenario. `tests/short` (654 tests) passes locally; ruff/pylint clean on the changed files.