### PR TITLE
Add tests pass/fail badge to GitHub Pages dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
             echo "🚀 FAST TEST MODE: Proceeding with default core test suite"
           fi
 
-          uv run pytest -v $TEST_PATHS --cov=rattlesnake --cov-report=html --cov-report=xml --cov-report=term-missing
+          uv run pytest -v $TEST_PATHS --cov=rattlesnake --cov-report=html --cov-report=xml --cov-report=term-missing --junitxml=junit.xml
 
           # github.head_ref is the source branch name on PRs; empty on push events.
           # github.ref_name is "83/merge" on PRs, which produces a 404 branch URL.
@@ -322,6 +322,7 @@ jobs:
             coverage_report.html
             htmlcov/
             coverage.xml
+            junit.xml
   docs_ui_generate:
     needs: changes
     if: |
@@ -577,6 +578,19 @@ jobs:
               --github_server_url ${{ github.server_url }}
           else
             echo "⚠️ No coverage report xml file found; skipping coverage badge generation."
+          fi
+
+          # Safe evaluation operator check for the JUnit XML report
+          if [ -f "coverage-report/junit.xml" ]; then
+            uv run python src/rattlesnake/cicd/badge_tests.py \
+              --input_file coverage-report/junit.xml \
+              --output_dir badges \
+              --github_repo ${{ github.repository }} \
+              --deploy_subdir ${{ env.DEPLOY_SUBDIR }} \
+              --run_id ${{ github.run_id }} \
+              --github_server_url ${{ github.server_url }}
+          else
+            echo "⚠️ No JUnit XML report found; skipping tests badge generation."
           fi
 
       - name: Assemble pages directory

--- a/src/rattlesnake/cicd/badge_tests.py
+++ b/src/rattlesnake/cicd/badge_tests.py
@@ -1,0 +1,107 @@
+"""
+Generates the Tests badge (SVG) and metadata (JSON) for CI/CD.
+"""
+
+import argparse
+import os
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+from rattlesnake.cicd.utilities import (
+    add_badge_args,
+    badge_image_download,
+    badge_metadata_json_write,
+)
+
+
+def parse_junit(input_file: str) -> tuple[int, int, int, int]:
+    """Parses a JUnit XML report to get test totals.
+
+    Args:
+        input_file: Path to a JUnit XML report (pytest --junitxml=...).
+
+    Returns:
+        A (total, passed, failed, skipped) tuple.
+    """
+    try:
+        tree = ET.parse(input_file)
+        root = tree.getroot()
+
+        if root.tag == "testsuites":
+            suites = root.findall("testsuite")
+        elif root.tag == "testsuite":
+            suites = [root]
+        else:
+            raise KeyError(f"Unexpected root tag: {root.tag}")
+
+        total = sum(int(suite.get("tests", 0)) for suite in suites)
+        failures = sum(int(suite.get("failures", 0)) for suite in suites)
+        errors = sum(int(suite.get("errors", 0)) for suite in suites)
+        skipped = sum(int(suite.get("skipped", 0)) for suite in suites)
+
+        failed = failures + errors
+        passed = total - failed - skipped
+        return total, passed, failed, skipped
+    except (ET.ParseError, KeyError, FileNotFoundError, ValueError) as e:
+        print(f"[!] Error parsing JUnit XML report: {e}")
+        return 0, 0, 0, 0
+
+
+def main():
+    """Main method for creating the badge."""
+    parser = argparse.ArgumentParser(description="Generate Tests badge and metadata.")
+    parser.add_argument(
+        "--input_file", required=True, help="JUnit XML report file (junit.xml)"
+    )
+    add_badge_args(parser)
+    args = parser.parse_args()
+
+    total, passed, failed, skipped = parse_junit(args.input_file)
+
+    message = f"{passed} pass {failed} fail"
+    if skipped > 0:
+        message += f" {skipped} skip"
+
+    color = "brightgreen" if failed == 0 else "red"
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        label = quote("tests")
+        encoded_message = quote(message)
+        badge_url = (
+            f"https://img.shields.io/badge/{label}-{encoded_message}-{color}.svg"
+        )
+        output_svg = str(Path(args.output_dir) / "tests.svg")
+        if badge_image_download(url=badge_url, output_path=output_svg):
+            print(f"[OK] Tests SVG badge saved to {args.output_dir}")
+
+        if all([args.github_repo, args.deploy_subdir, args.run_id]):
+            metadata = {
+                "total": total,
+                "passed": passed,
+                "failed": failed,
+                "skipped": skipped,
+                "message": message,
+                "color": color,
+                "workflow_url": (
+                    f"{args.github_server_url}/{args.github_repo}/actions/"
+                    f"workflows/ci.yml?query=branch%3A{args.deploy_subdir}"
+                ),
+                "run_id": args.run_id,
+                "artifact_url": (
+                    f"{args.github_server_url}/{args.github_repo}/actions/"
+                    f"runs/{args.run_id}"
+                ),
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            output_json = str(Path(args.output_dir) / "tests-info.json")
+            badge_metadata_json_write(metadata=metadata, output_path=output_json)
+            print(f"[OK] Tests JSON metadata saved to {args.output_dir}")
+
+    print(f"Tests badge processing complete: {message} ({color})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rattlesnake/cicd/report_dashboard.py
+++ b/src/rattlesnake/cicd/report_dashboard.py
@@ -108,7 +108,7 @@ def generate_dashboard_html(metadata: ReportMetadata) -> str:
                         </div>
                     </a>
 
-                    <div class="grid grid-cols-2 gap-4">
+                    <div class="grid grid-cols-3 gap-4">
                         <a href="main/reports/lint/index.html"
                            class="hover-card p-4 bg-white rounded-xl shadow-sm border
                                   border-slate-200 hover:border-blue-600">
@@ -122,6 +122,13 @@ def generate_dashboard_html(metadata: ReportMetadata) -> str:
                             <span class="block text-xs font-bold text-slate-400
                                          uppercase mb-2">Test Coverage</span>
                             <img src="main/badges/coverage.svg" alt="Coverage" class="h-5">
+                        </a>
+                        <a href="{github_url}/actions/workflows/ci.yml?query=branch%3Amain"
+                           class="hover-card p-4 bg-white rounded-xl shadow-sm border
+                                  border-slate-200 hover:border-blue-600">
+                            <span class="block text-xs font-bold text-slate-400
+                                         uppercase mb-2">Tests</span>
+                            <img src="main/badges/tests.svg" alt="Tests" class="h-5">
                         </a>
                     </div>
                 </div>
@@ -154,7 +161,7 @@ def generate_dashboard_html(metadata: ReportMetadata) -> str:
                         </div>
                     </a>
 
-                    <div class="grid grid-cols-2 gap-4">
+                    <div class="grid grid-cols-3 gap-4">
                         <a href="dev/reports/lint/index.html"
                            class="hover-card p-4 bg-white rounded-xl shadow-sm border
                                   border-slate-200 hover:border-orange-500">
@@ -168,6 +175,13 @@ def generate_dashboard_html(metadata: ReportMetadata) -> str:
                             <span class="block text-xs font-bold text-slate-400
                                          uppercase mb-2">Test Coverage</span>
                             <img src="dev/badges/coverage.svg" alt="Coverage" class="h-5">
+                        </a>
+                        <a href="{github_url}/actions/workflows/ci.yml?query=branch%3Adev"
+                           class="hover-card p-4 bg-white rounded-xl shadow-sm border
+                                  border-slate-200 hover:border-orange-500">
+                            <span class="block text-xs font-bold text-slate-400
+                                         uppercase mb-2">Tests</span>
+                            <img src="dev/badges/tests.svg" alt="Tests" class="h-5">
                         </a>
                     </div>
                 </div>

--- a/tests/short/cicd/test_badge_tests.py
+++ b/tests/short/cicd/test_badge_tests.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for badge_tests.py — Tests Badge Generator.
+"""
+
+import json
+from unittest.mock import patch
+
+from rattlesnake.cicd.badge_tests import main, parse_junit
+
+
+def test_parse_junit_testsuite_root(tmp_path):
+    """Test parsing a JUnit XML report with a bare <testsuite> root."""
+    junit_xml = (
+        '<testsuite name="pytest" tests="654" failures="0" errors="0" '
+        'skipped="0"></testsuite>'
+    )
+    file = tmp_path / "junit.xml"
+    file.write_text(junit_xml)
+    assert parse_junit(str(file)) == (654, 654, 0, 0)
+
+
+def test_parse_junit_testsuites_root(tmp_path):
+    """Test parsing a JUnit XML report with a <testsuites><testsuite> root."""
+    junit_xml = (
+        "<testsuites>"
+        '<testsuite name="pytest" tests="10" failures="1" errors="1" '
+        'skipped="2"></testsuite>'
+        "</testsuites>"
+    )
+    file = tmp_path / "junit.xml"
+    file.write_text(junit_xml)
+    # total=10, failed=failures+errors=2, skipped=2, passed=10-2-2=6
+    assert parse_junit(str(file)) == (10, 6, 2, 2)
+
+
+def test_parse_junit_invalid(tmp_path):
+    """Test parsing a malformed XML file."""
+    file = tmp_path / "bad.xml"
+    file.write_text("<invalid")
+    assert parse_junit(str(file)) == (0, 0, 0, 0)
+
+
+@patch("requests.get")
+def test_main_success_all_pass(mock_get, tmp_path):
+    """Test main function for a fully-passing suite badge generation."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.content = b"svg-content"
+
+    junit_xml = (
+        '<testsuite name="pytest" tests="654" failures="0" errors="0" '
+        'skipped="0"></testsuite>'
+    )
+    input_file = tmp_path / "junit.xml"
+    input_file.write_text(junit_xml)
+    output_dir = tmp_path / "badges"
+
+    test_args = [
+        "badge_tests.py",
+        "--input_file",
+        str(input_file),
+        "--output_dir",
+        str(output_dir),
+        "--github_repo",
+        "owner/repo",
+        "--deploy_subdir",
+        "dev",
+        "--run_id",
+        "123",
+    ]
+    with patch("sys.argv", test_args):
+        main()
+
+    assert (output_dir / "tests.svg").exists()
+    assert (output_dir / "tests.svg").read_bytes() == b"svg-content"
+    assert (output_dir / "tests-info.json").exists()
+    with open(output_dir / "tests-info.json", "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+        assert metadata["total"] == 654
+        assert metadata["passed"] == 654
+        assert metadata["failed"] == 0
+        assert metadata["skipped"] == 0
+        assert metadata["message"] == "654 pass 0 fail"
+        assert metadata["color"] == "brightgreen"
+
+
+@patch("requests.get")
+def test_main_with_failures(mock_get, tmp_path):
+    """Test main function for a badge generation with failing/skipped tests."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.content = b"svg-content"
+
+    junit_xml = (
+        '<testsuite name="pytest" tests="10" failures="2" errors="1" '
+        'skipped="1"></testsuite>'
+    )
+    input_file = tmp_path / "junit.xml"
+    input_file.write_text(junit_xml)
+    output_dir = tmp_path / "badges"
+
+    test_args = [
+        "badge_tests.py",
+        "--input_file",
+        str(input_file),
+        "--output_dir",
+        str(output_dir),
+        "--github_repo",
+        "owner/repo",
+        "--deploy_subdir",
+        "main",
+        "--run_id",
+        "456",
+    ]
+    with patch("sys.argv", test_args):
+        main()
+
+    with open(output_dir / "tests-info.json", "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+        assert metadata["failed"] == 3
+        assert metadata["passed"] == 6
+        assert metadata["skipped"] == 1
+        assert metadata["message"] == "6 pass 3 fail 1 skip"
+        assert metadata["color"] == "red"

--- a/tests/short/cicd/test_report_dashboard.py
+++ b/tests/short/cicd/test_report_dashboard.py
@@ -26,6 +26,7 @@ def test_generate_dashboard_html():
     assert "https://github.com/owner/repo" in html
     assert "main/badges/lint.svg" in html
     assert "dev/badges/coverage.svg" in html
+    assert "dev/badges/tests.svg" in html
     assert "2026-04-24" in html
     assert "(expires 2026-07-23)" in html
 


### PR DESCRIPTION
## Summary

Adds a "tests" badge (e.g. `tests: 659 pass 0 fail`) to the GitHub Pages
dashboard's Test Coverage section for both the `main` and `dev` columns,
matching the pattern used in `hovey/dictk`'s README — but landing in this
repo's dashboard (generated by `report_dashboard.py`) rather than
`README.md`, per this repo's own badge conventions.

- `src/rattlesnake/cicd/badge_tests.py` (new): parses a JUnit XML report
  and generates a shields.io "tests" badge + `tests-info.json`, following
  the same shape as the existing `badge_coverage.py`/`badge_lint.py`.
- `.github/workflows/ci.yml`: the `coverage` job now runs pytest with
  `--junitxml=junit.xml` and uploads it; the `deploy` job generates
  `badges/tests.svg` alongside the existing lint/coverage badges.
- `src/rattlesnake/cicd/report_dashboard.py`: each branch's card grid
  grows from 2 to 3 columns, adding a "Tests" card next to "Code Quality"
  and "Test Coverage".
- Matching unit tests added/updated.

## Known caveat

`main` currently has no `.github/workflows`, tests, or `src/` layout at
all (it's a legacy pre-refactor snapshot well behind `dev`), so its Tests
card will 404 until `main` gets CI infrastructure of its own — the same
pre-existing state as the current lint/coverage badges for `main`. Only
`dev`'s badge will populate once this merges and a `dev` push runs.

## Verification

- New tests (`tests/short/cicd/test_badge_tests.py`) pass; full
  `tests/short/cicd` suite (71 tests) passes.
- Verified `badge_tests.py` end-to-end against a real local
  `pytest --junitxml=...` run of the full `tests/short` suite (659 pass,
  0 fail) — correct SVG and JSON output.
- CI run on this branch passed: https://github.com/sandialabs/rattlesnake-vibration-controller/actions/runs/33920089758
  (`deploy` job correctly skipped — it only runs on pushes to `main`/`dev`).